### PR TITLE
fix 401, add mixin for base app

### DIFF
--- a/mixins/sapphire-app.js
+++ b/mixins/sapphire-app.js
@@ -1,0 +1,28 @@
+export default {
+    created() {
+        this.$store.dispatch('user/loadToken').catch(() => {
+            this.redirectToLogin();
+        });
+        this.$store.dispatch('user/loadRefreshToken');
+        this.$store.dispatch('mercure/loadToken');
+    },
+    watch: {
+        loggedIn(isLoggedIn) {
+            if (!isLoggedIn) {
+                this.redirectToLogin();
+            }
+        }
+    },
+    methods: {
+        redirectToLogin() {
+            if (this.$router.currentRoute.path !== '/login') {
+                this.$router.replace('/login');
+            }
+        }
+    },
+    computed: {
+        loggedIn() {
+            return this.$store.state.user.user !== null;
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@keicreations/sapphire-vue",
-    "version": "2.0.6",
+    "version": "2.1",
     "description": "Vue components to communicate with API platform and Mercure.",
     "repository": {
         "type": "git",

--- a/store/modules/user.js
+++ b/store/modules/user.js
@@ -32,7 +32,7 @@ const getters = {};
 const actions = {
     clear(context) {
         context.dispatch('setRefreshToken', null);
-        context.dispatch('setToken', null);
+        context.dispatch('setToken', null).catch(()=>{});
     },
     useRefreshToken(context) {
         return new Promise((resolve, reject) => {
@@ -80,7 +80,8 @@ const actions = {
                 let payload = jwt_decode(token);
                 context.dispatch('setUser', payload.user_id).then(resolve).catch(reject);
             } else {
-                context.dispatch('setUser', null).then(resolve).catch(reject);
+                context.dispatch('setUser', null);
+                reject();
             }
         });
     },


### PR DESCRIPTION
This fixes the 401 error again. This also adds a mixin to be used in App.vue, which takes over the token loading and the login watcher.